### PR TITLE
fix: no protocol relative url

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,7 @@ module.exports = function module (moduleOptions) {
   const options = Object.assign({}, defaults, this.options.stripe, moduleOptions);
 
   this.options.head.script.push({
-    src: `//js.stripe.com/${options.version}/`,
+    src: `https://js.stripe.com/${options.version}/`,
     defer: options.defer,
     async: options.async,
   });


### PR DESCRIPTION
Having a protocol relative URL is causing issues in IE11, where the Stripe library doesn't load at all. Explicitly setting `https` works fine in dev environment – Stripe still emits the same warning saying that `http` can only be used for testing.