### PR TITLE
fix: do not append stripeAccount to options if not specified

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -6,11 +6,15 @@ export default async function (context, inject) {
   let stripePlugin = null
   try {
     const { publishableKey, stripeAccount, locale, version: apiVersion } = parsedOptions
-    stripePlugin = await loadStripe(publishableKey, {
-      stripeAccount,
+
+    const options = {
       locale,
       apiVersion
-    })
+    }
+
+    if (stripeAccount) options.stripeAccount = stripeAccount
+
+    stripePlugin = await loadStripe(publishableKey, options)
   } catch (e) {
     console.error(`[nuxt-stripe-module] ${e.message}`)
   }


### PR DESCRIPTION
fixes #31 

