### PR TITLE
feat: runtime config

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,10 +10,6 @@ module.exports = function module (moduleOptions) {
 
   const options = Object.assign({}, defaults, this.options.stripe, moduleOptions)
 
-  if (!options.publishableKey) {
-    throw new Error('A Stripe publishable key is required.')
-  }
-
   this.addPlugin({
     src: path.resolve(__dirname, './templates/plugin.js'),
     ssr: false,

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -5,7 +5,14 @@ export default async function (context, inject) {
 
   let stripePlugin = null
   try {
-    const { publishableKey, stripeAccount, locale, version: apiVersion } = parsedOptions
+    const {
+      publishableKey: parsedPublishableKey,
+      stripeAccount,
+      locale,
+      version: apiVersion
+    } = parsedOptions
+    const publishableKey = parsedPublishableKey ||
+      context.$config.stripe.publishableKey
     stripePlugin = await loadStripe(publishableKey, {
       stripeAccount,
       locale,

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -13,6 +13,11 @@ export default async function (context, inject) {
     } = parsedOptions
     const publishableKey = parsedPublishableKey ||
       context.$config.stripe.publishableKey
+
+    if (!publishableKey) {
+      throw new Error('A Stripe publishable key is required.')
+    }
+
     stripePlugin = await loadStripe(publishableKey, {
       stripeAccount,
       locale,


### PR DESCRIPTION
Enables publishableKey to be injected in [runtime config](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-runtime-config/),

Context:
Currently, this module is set up to fail on build stage if the publishableKey option is empty.
We are developing and distributing our application via docker image, building our image once and run it in many environments with many configs.
So, we can't have a stripe publishableKey be present when building image.
We want the key to be injected in to the container at runtime and all of our open source modules are already using runtmie configuration which is perfect.
We're using this modification to run currently and I think this might help other developers looking for runtime configuration option for nuxt-stripe-module.
